### PR TITLE
TRON-8-revamp: Add the functionality to allow user to change his/her …

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,3 +6,4 @@
 @import 'forgot_password';
 @import 'navbar';
 @import 'edit_profile';
+@import 'edit_password';

--- a/app/assets/stylesheets/edit_password.scss
+++ b/app/assets/stylesheets/edit_password.scss
@@ -1,0 +1,73 @@
+.custom-gutter-x {
+  margin-right: 0.75rem;
+  margin-left: -0.75rem;
+}
+body {
+  background-color: #f2f3f3;
+}
+.show-label{
+  font-family: sans-serif;
+  margin-bottom: 5px;
+}
+.mb-20{
+  margin-bottom: 20px;
+}
+.custom-form-class{
+  padding: 20px;
+  background-color: #fff;
+}
+.editpassword-page{
+  padding: 20px;
+}
+.editpassword-h1{
+  margin-left: 30px;
+  font-size: 24px;
+  font-family: sans-serif;
+  font-weight: 700;
+  color: #233d7b;
+  line-height: 28px;
+}
+.editpassword-container .form-control{
+  border: 1px solid #e6e6e6;
+  background-color: #fff;
+  border-radius: 4px;
+  height: 54px;
+  padding: 6px 18px;
+  font-size: 14px;
+  vertical-align: middle;
+  margin: 0px 0px 40px;
+}
+#password_confirmation {
+  margin-bottom: 0;
+}
+.password-button .btn{
+  font-size: 23px;
+  font-family: sans-serif;
+  min-width: 20px;
+  padding: 6px 12px;
+  border-color: #1d331d;
+  background-color:#233d7b;
+}
+.btn-save{
+  border-top: 0;
+}
+.alert-edit{
+  width: 90%;
+  margin-left: 0.8rem;
+  margin-top: 1rem;
+  margin-bottom: 3rem;
+}
+.password-match-error.error-div{
+  font-family: sans-serif;
+  color: red;
+  margin-left: 10px;
+  display: none;
+}
+input.is-valid {
+  background-color:#DFF0D8 !important;
+  color: green !important;
+}
+input.is-invalid {
+  background-color: #F2DEDE !important;
+  color: red !important;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,9 +27,31 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit_password
+    @user = current_user
+  end
+  
+  def update_password
+    @user = current_user
+  
+    if @user.valid_password?(user_params[:current_password])
+      if @user.update_with_password(user_params)
+        @user.save
+        redirect_to root_path, notice: 'Password successfully updated.'
+      else
+        flash.now[:custom_alert] = @user.errors.full_messages.join(", ") unless @user.errors.details.key?(:current_password)
+        render :edit_password
+      end
+    else
+      flash.now[:custom_alert] = "Incorrect current password."
+      render :edit_password
+    end
+  end
+  
+
   private
 
   def user_params
-    params.require(:user).permit(:email, :password, :full_name, :profile_picture)
+    params.require(:user).permit(:email, :password, :password_confirmation, :full_name, :profile_picture, :current_password)
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,3 +6,4 @@ import './sign_in';
 import './forgot_password';
 import './navbar_sign_in.js';
 import './navbar_sign_up.js';
+import './edit_password.js';

--- a/app/javascript/packs/edit_password.js
+++ b/app/javascript/packs/edit_password.js
@@ -1,0 +1,54 @@
+$(document).ready(function() {
+  var password = $('#password').val();
+  var confirmPassword = $('#password_confirmation').val();
+  $('.password-match-error').hide();
+
+  $('#reset_button').click(function(e) {
+    var password = $('#password').val();
+    var confirmPassword = $('#password_confirmation').val();
+    
+    var count = 0;
+    if (password !== confirmPassword) {
+      count++;
+      e.preventDefault();
+      $('.password-match-error').show();
+      localStorage.setItem('count', count);
+      $('#password').removeClass('is-invalid').addClass('is-valid');
+      $('#password_confirmation').removeClass('is-valid').addClass('is-invalid');
+    
+    }
+
+    if (localStorage.getItem('count') > 0){
+      $('#password, #password_confirmation').on('input',function(){
+        var fieldPassword = $('#password').val();
+        var fieldConfirmPassword = $('#password_confirmation').val();
+        if (fieldPassword == '' && fieldConfirmPassword == '') {
+            $('#password, #password_confirmation').css('background-image', 'none');
+        } else if (fieldPassword == '') {
+            $('#password').css('background-image', 'none');
+        } else if (fieldConfirmPassword == '') {
+            $('#password_confirmation').css('background-image', 'none');
+        }
+      });
+    
+      $('#password, #password_confirmation').on('input', function() {
+        var password = $('#password').val();
+        var confirmPassword = $('#password_confirmation').val();
+
+        if (password && confirmPassword && confirmPassword.length && password !== confirmPassword) {
+          $('.password-match-error').show();
+          $('#password').removeClass('is-invalid').addClass('is-valid');
+          $('#password_confirmation').removeClass('is-valid').addClass('is-invalid');
+        } 
+        else {
+          $('#password_confirmation').removeClass('is-invalid').addClass('is-valid');
+          $('.password-match-error').hide();
+        }
+      });
+    }
+  });
+});
+
+$(window).on('beforeunload', function() {
+  localStorage.removeItem('count');
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,7 @@ class User < ApplicationRecord
   has_one_attached :profile_picture
   validates :full_name, :gender, :country, :city, :username, presence: true
   validates :username, uniqueness: true
+  validates :password, presence: true
+  validates :password_confirmation, presence: true
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ApplicationRecord
   has_one_attached :profile_picture
   validates :full_name, :gender, :country, :city, :username, presence: true
   validates :username, uniqueness: true
-  validates :password, presence: true
-  validates :password_confirmation, presence: true
+  validates :password, :password_confirmation, presence: true
   
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -106,7 +106,7 @@
               <div class="form-group row">
                 <%= form.label :password, "Password", class:"col-md-4 text-md-end" %>
                 <div class="col-md-6 input-edit ">
-                  <%= link_to 'Change Password', edit_user_registration_path, class: "btn btn-outline-primary btn-password" %>
+                  <%= link_to 'Change Password', change_password_path, class: "btn btn-outline-primary btn-password" %>
                 </div>
               </div>
 

--- a/app/views/users/edit_password.html.erb
+++ b/app/views/users/edit_password.html.erb
@@ -1,0 +1,64 @@
+<%= render 'users/backnavbar' %>
+<% if flash[:custom_alert] %>
+  <div class="alert alert-danger alert-dismissible fade show alert-edit" role="alert">
+    <strong><%= flash[:custom_alert] %></strong>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  </div>
+<% end %>
+
+<div class="row custom-gutter-x">
+  <div class="col-md-6 offset-md-3">
+    <h1 class="editpassword-h1">Change Password</h1>
+  </div>
+</div>
+
+<div class="editpassword-container">
+  <div class="container">
+    <div class="row change-password justify-content-center">
+      <div class="col-md-6">
+        <%= form_with model: @user, url: change_password_path, method: :patch, html: { class: 'custom-form-class' } do |form| %>
+          <label class="show-label">
+            <strong>Change your password below</strong>
+          </label>
+          <br>
+          <label class="show-label mb-20">
+            <strong><%= current_user.email %></strong>
+          </label>
+
+          <div class="form-group">
+            <div class="text-center">
+              <%= form.password_field :current_password, placeholder: 'Type Your Current Password', class: "form-control #{'is-valid' if flash[:success]} #{'is-invalid' if flash[:error]}", id: "current_password" %>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="text-center">
+              <%= form.password_field :password, placeholder: 'Type Your Password', class: "form-control", id: "password" %>
+              <% if @user && @user.errors[:password].present? %>
+                <div class="invalid-feedback">
+                  <%= @user.errors[:password].first %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        
+          <div class="form-group">
+            <div class=" ">
+              <%= form.password_field :password_confirmation, placeholder: 'Re-type Your Password', class: "form-control", id: "password_confirmation" %>
+              <% if @user && @user.errors[:password_confirmation].present? %>
+                <div class="invalid-feedback">
+                  <p class="text-danger"><%= @user.errors[:password_confirmation].first %></p>
+                </div>
+              <% end %>
+              <div class="password-match-error error-div">Password do not match.</div>
+            </div>
+          </div>
+
+          <div class="btn-save text-center password-button">
+            <%= form.button 'Reset Password', type: 'submit', class: 'btn btn-primary btn-large', id: "reset_button"  %>
+          </div>            
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,7 @@ Rails.application.routes.draw do
   patch '/profile', to: 'users#update'
   get '/profile', to: 'users#profile', as: 'user_profile'
   patch '/update_profile_picture', to: 'users#update_profile_picture', as: 'update_profile_picture'
+  get '/change_password', to: 'users#edit_password', as: 'change_password'
+  patch '/change_password', to: 'users#update_password'
 
 end


### PR DESCRIPTION
Ticket: https://pakw.atlassian.net/browse/TRON-8

**Why?**

In the process of completing the edit profile page for the users where users can edit and update their personal data/details.

**Acceptance Criteria:**

- On edit profile page, when a user click on change password HyperLink, redirect to the reset password page (route).
- Once user is being redirected to reset password page, show the attached form below to the user, where user should first enter its old password, then take his/her new password and confirm password.
- Must check these validations/criteria for password reset:
- If user enters incorrect current password throw a flash message and redirect back user to the same page. (as show in the screenshot attached).
- New allowed password validation should remain same as we’ve added on while creating a new User (sign up form), (at least 1 uppercase, at least 1 lowercase, at least 1 special character, characters length must be at least 8 characters)
- New password and confirm password must match, if not, add a validation error as show in the screenshot attached and redirect it back to the same page. Also change the message to: “New password and confirm password does not match“.