### PR TITLE
TRON-17-revamp: Fix Ad Description field on post add form

### DIFF
--- a/app/assets/stylesheets/new_ad.scss
+++ b/app/assets/stylesheets/new_ad.scss
@@ -253,3 +253,22 @@
 .number-error-message{
   font-size: 1rem;
 }
+#resetbutton {
+  margin-left: 1rem !important;
+  cursor: pointer;
+  color: #518ecb;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  font-size: inherit;
+}
+#resetbutton:hover {
+  color: gray;
+}
+
+#ad-description::placeholder {
+ padding-top: 10px;
+ padding-left: 12px;
+ padding-right: 10px;
+}

--- a/app/javascript/packs/new_ad.js
+++ b/app/javascript/packs/new_ad.js
@@ -1,18 +1,51 @@
 $(document).ready(function() {
-  var maxWords = 1000;
-
-  // Initial update
+  var maxCharacters = (995);
   updateRemainingWords();
-
-  // Update on input
   $('#ad-description').on('input', updateRemainingWords);
 
+  $('#resetbutton').click(function(){
+    $('#ad-description').val('');
+    limitTextareaCharacter();
+  });
+
+  $('.design-span').on('click',function(){
+    var suggestiontext = $(this).text() + '.';
+    var currentDescription = $('#ad-description').val();
+    var newDescription =  currentDescription + ' ' + suggestiontext;
+    $('#ad-description').val(newDescription);
+    checkDescriptionValue();
+    updateRemainingWords(); 
+    limitTextareaCharacter();
+  });
+
+  $('#ad-description').on('input', function(){
+    checkDescriptionValue();
+    limitTextareaCharacter();
+  });
+
+  function checkDescriptionValue(){
+    var descriptionValue = $('#ad-description').val().trim();
+    if (descriptionValue !== ""){
+      $('#ad-description').css('background-color' , ' rgb(172, 243, 172)');
+      $('.description-error').hide();
+      } else {
+      $('#ad-description').css('background-color' , 'lightpink')
+      $('.description-error').show();
+        }
+  }
+
   function updateRemainingWords() {
-    var currentWords = $('#ad-description').val().match(/\S+/g) || [];
-    var remainingWords = maxWords - currentWords.length;
+      var currentText = $('#ad-description').val();
+    var remainingCharacters = maxCharacters -  currentText.length;
 
     // Display the remaining words count
-    $('#remaining-words').text(remainingWords);
+    $('#remaining-words').text(remainingCharacters );
+  }
+  function limitTextareaCharacter(){
+    var currentText = $('#ad-description').val();
+    if (currentText.length >= maxCharacters){
+      $('#ad-description').val(currentText.substring(0,maxCharacters));
+    }
   }
 
   $('#toggleButton').on('click', function() {
@@ -24,17 +57,17 @@ $(document).ready(function() {
         'overflow': 'visible',
         'height': 'auto'
       });
-      buttonText.text('Show Less');
+      buttonText.html('Show Less Suggestions <i class="fas fa-chevron-circle-up"></i>');
     } else {
       suggestion.css({
         'overflow': 'hidden',
         'height': '88px'
       });
-      buttonText.text('Show More');
+      buttonText.html('Show More Suggestions <i class="fas fa-chevron-circle-down"></i>');
     }
   });
 
-    var textField = $('.validate-on-click');
+  var textField = $('.validate-on-click');
   var errorMessage = $('.error-message');
 
   textField.on('focus', function() {
@@ -61,6 +94,7 @@ $(document).ready(function() {
     } 
   });
 });
+
 
 (function ($) {
   $.fn.num2str = function (num) {

--- a/app/views/used_cars/new_ad.html.erb
+++ b/app/views/used_cars/new_ad.html.erb
@@ -104,9 +104,9 @@
           </label>
           <div class="col-md-8">
             <div class="text-end" style="text-align: end;font-size: 12px;">
-              Remaining Words: <span id="remaining-words">1000</span>
+            Remaining Words: <span id="remaining-words">1000</span><span id="resetbutton"><strong>Reset<strong></span>
             </div>
-            <%= form.text_area :description, class: "form-control", rows: 6, id: "ad-description" %>
+            <%= form.text_area :description, class: "form-control", rows: 6, id: "ad-description", placeholder: "Describe Your car:\nExample:Alloy rim, first owner, genuine parts, maintained by authorized workshop, excellent mileage, original paint etc." %>
             <div class="section2-para1">
               <p>You can also use this suggestions</p>
               <div id="suggestion">


### PR DESCRIPTION
Ticket: https://pakw.atlassian.net/browse/TRON-17

**Description**

**Acceptance Criteria:**

- Add description field button “show more suggestion” is not working. it should expand and shrink on click to show or hide further suggestions.
- upon choosing from suggestion that suggestion should be added in to the Add description field.
- User can also add custom suggestions there.
- “Inside out fully original“ should be default input in the Add description field.
- Default placeholder text should be displayed if no input is added to the field.
- Max length of characters should be 995 characters.
- Reset button on upper right corner should make the field empty again upon click.
- Upon adding the input it its background should turn green indicating the correct input.
- If no input is added it should highlight the background as red and throw an error message under the field saying “value is required“
- Relative Screenshots are attached.